### PR TITLE
add exponential backoff strategy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 [dependencies]
 tokio = { version = "1", features = ["time", "net"] }
 log = "0.4"
+rand = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "fs", "io-util"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Provides options to configure the behavior of stubborn-io items,
 //! specifically related to reconnect behavior.
 
+use crate::strategies::get_standard_reconnect_strategy;
 use std::time::Duration;
 
 pub type DurationIterator = Box<dyn Iterator<Item = Duration> + Send + Sync>;
@@ -88,26 +89,4 @@ impl ReconnectOptions {
         self.on_connect_fail_callback = Box::new(cb);
         self
     }
-}
-
-fn get_standard_reconnect_strategy() -> DurationIterator {
-    let initial_attempts = vec![
-        Duration::from_secs(5),
-        Duration::from_secs(10),
-        Duration::from_secs(20),
-        Duration::from_secs(30),
-        Duration::from_secs(40),
-        Duration::from_secs(50),
-        Duration::from_secs(60),
-        Duration::from_secs(60 * 2),
-        Duration::from_secs(60 * 5),
-        Duration::from_secs(60 * 10),
-        Duration::from_secs(60 * 20),
-    ];
-
-    let repeat = std::iter::repeat(Duration::from_secs(60 * 30));
-
-    let forever_iterator = initial_attempts.into_iter().chain(repeat);
-
-    Box::new(forever_iterator)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! Provides options to configure the behavior of stubborn-io items,
 //! specifically related to reconnect behavior.
 
-use crate::strategies::get_standard_reconnect_strategy;
+use crate::strategies::ExpBackoffStrategy;
 use std::time::Duration;
 
 pub type DurationIterator = Box<dyn Iterator<Item = Duration> + Send + Sync>;
@@ -33,7 +33,7 @@ impl ReconnectOptions {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         ReconnectOptions {
-            retries_to_attempt_fn: Box::new(get_standard_reconnect_strategy),
+            retries_to_attempt_fn: Box::new(|| Box::new(ExpBackoffStrategy::default().into_iter())),
             exit_if_first_connect_fails: true,
             on_connect_callback: Box::new(|| {}),
             on_disconnect_callback: Box::new(|| {}),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
 //! ```
 
 pub mod config;
+pub mod strategies;
 
 // in the future, there may be a mod for synchronous regular io too, which is why
 // tokio is specifically chosen to place the async stuff
@@ -62,5 +63,7 @@ pub mod tokio;
 
 #[doc(inline)]
 pub use self::config::ReconnectOptions;
+#[doc(inline)]
+pub use self::strategies::ExpBackoffStrategy;
 #[doc(inline)]
 pub use self::tokio::StubbornTcpStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,4 @@ pub mod tokio;
 #[doc(inline)]
 pub use self::config::ReconnectOptions;
 #[doc(inline)]
-pub use self::strategies::ExpBackoffStrategy;
-#[doc(inline)]
 pub use self::tokio::StubbornTcpStream;

--- a/src/strategies.rs
+++ b/src/strategies.rs
@@ -1,0 +1,154 @@
+use crate::config::DurationIterator;
+use rand::{rngs::StdRng, Rng, SeedableRng};
+use std::time::Duration;
+
+pub(crate) fn get_standard_reconnect_strategy() -> DurationIterator {
+    let initial_attempts = vec![
+        Duration::from_secs(5),
+        Duration::from_secs(10),
+        Duration::from_secs(20),
+        Duration::from_secs(30),
+        Duration::from_secs(40),
+        Duration::from_secs(50),
+        Duration::from_secs(60),
+        Duration::from_secs(60 * 2),
+        Duration::from_secs(60 * 5),
+        Duration::from_secs(60 * 10),
+        Duration::from_secs(60 * 20),
+    ];
+
+    let repeat = std::iter::repeat(Duration::from_secs(60 * 30));
+
+    let forever_iterator = initial_attempts.into_iter().chain(repeat);
+
+    Box::new(forever_iterator)
+}
+
+/// Type used for defining the exponential backoff strategy.
+/// # Examples
+///
+/// ```
+/// use std::time::Duration;
+/// use stubborn_io::{ReconnectOptions, ExpBackoffStrategy};
+///
+/// // With the below strategy, the stubborn-io item will try to reconnect infinitely,
+/// // waiting an exponentially increasing (by 2) value with 5% random jitter. Once the
+/// // wait would otherwise exceed the maxiumum of 30 seconds, it will instead wait 30
+/// // seconds.
+///
+/// let options = ReconnectOptions::new().with_retries_generator(|| {
+///     ExpBackoffStrategy::new(Duration::from_secs(1), 2, 0.05)
+///         .with_max(Duration::from_secs(30))
+/// });
+/// ```
+pub struct ExpBackoffStrategy {
+    min: Duration,
+    max: Option<Duration>,
+    factor: u32,
+    jitter: f64,
+    seed: Option<u64>,
+}
+
+impl ExpBackoffStrategy {
+    pub fn new(min: Duration, factor: u32, jitter: f64) -> Self {
+        Self {
+            min,
+            max: None,
+            factor,
+            jitter,
+            seed: None,
+        }
+    }
+
+    /// Set the exponential backoff strategy's maximum wait value to the given duration.
+    /// Otherwise, this value will be the maximum possible duration.
+    pub fn with_max(mut self, max: Duration) -> Self {
+        self.max = Some(max);
+        self
+    }
+
+    /// Set the seed used to generate jitter. Otherwise, will set RNG via entropy.
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+}
+
+impl IntoIterator for ExpBackoffStrategy {
+    type Item = Duration;
+    type IntoIter = ExpBackoffIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let init = self.min.as_secs_f64();
+        let rng = match self.seed {
+            Some(seed) => StdRng::seed_from_u64(seed),
+            None => StdRng::from_entropy(),
+        };
+
+        ExpBackoffIter {
+            strategy: self,
+            init,
+            pow: 0,
+            rng,
+        }
+    }
+}
+
+/// Iterator class for [ExpBackoffStrategy]
+pub struct ExpBackoffIter {
+    strategy: ExpBackoffStrategy,
+    init: f64,
+    pow: u32,
+    rng: StdRng,
+}
+
+impl Iterator for ExpBackoffIter {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.pow += 1;
+        let base = self.init * self.strategy.factor.pow(self.pow) as f64;
+        let jitter = base * self.strategy.jitter * (self.rng.gen::<f64>() * 2. - 1.);
+        let current = Duration::from_secs_f64(base + jitter);
+        match self.strategy.max {
+            Some(max) => Some(max.min(current)),
+            None => Some(current),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ExpBackoffStrategy;
+    use std::time::Duration;
+
+    macro_rules! assert_close_to {
+        ($item:expr, $value:expr) => {
+            assert_close_to!($item, $value, 0.001_f64)
+        };
+        ($item:expr, $value:expr, $eps: expr) => {
+            assert!($item >= ($value - $eps));
+            assert!($item <= ($value + $eps));
+        };
+    }
+
+    #[test]
+    fn test_exponential_backoff_jitter_bounds() {
+        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 2, 0.1).into_iter();
+        let first = backoff_iter.next();
+        assert_close_to!(first.unwrap().as_secs_f64(), 2.0_f64, 0.2_f64);
+        let second = backoff_iter.next();
+        assert_close_to!(second.unwrap().as_secs_f64(), 4.0_f64, 0.4_f64);
+    }
+
+    #[test]
+    fn test_exponential_backoff_max_value() {
+        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 4, 0.0)
+            .with_max(Duration::from_secs(2))
+            .into_iter();
+        let first = backoff_iter.next();
+        assert_close_to!(first.unwrap().as_secs_f64(), 2.0);
+        let second = backoff_iter.next();
+        assert_close_to!(second.unwrap().as_secs_f64(), 2.0);
+    }
+}

--- a/src/strategies.rs
+++ b/src/strategies.rs
@@ -1,35 +1,13 @@
-use crate::config::DurationIterator;
+//! Provides the strategies used in stubborn io items
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::time::Duration;
-
-pub(crate) fn get_standard_reconnect_strategy() -> DurationIterator {
-    let initial_attempts = vec![
-        Duration::from_secs(5),
-        Duration::from_secs(10),
-        Duration::from_secs(20),
-        Duration::from_secs(30),
-        Duration::from_secs(40),
-        Duration::from_secs(50),
-        Duration::from_secs(60),
-        Duration::from_secs(60 * 2),
-        Duration::from_secs(60 * 5),
-        Duration::from_secs(60 * 10),
-        Duration::from_secs(60 * 20),
-    ];
-
-    let repeat = std::iter::repeat(Duration::from_secs(60 * 30));
-
-    let forever_iterator = initial_attempts.into_iter().chain(repeat);
-
-    Box::new(forever_iterator)
-}
 
 /// Type used for defining the exponential backoff strategy.
 /// # Examples
 ///
 /// ```
 /// use std::time::Duration;
-/// use stubborn_io::{ReconnectOptions, ExpBackoffStrategy};
+/// use stubborn_io::{ReconnectOptions, strategies::ExpBackoffStrategy};
 ///
 /// // With the below strategy, the stubborn-io item will try to reconnect infinitely,
 /// // waiting an exponentially increasing (by 2) value with 5% random jitter. Once the
@@ -37,20 +15,20 @@ pub(crate) fn get_standard_reconnect_strategy() -> DurationIterator {
 /// // seconds.
 ///
 /// let options = ReconnectOptions::new().with_retries_generator(|| {
-///     ExpBackoffStrategy::new(Duration::from_secs(1), 2, 0.05)
+///     ExpBackoffStrategy::new(Duration::from_secs(1), 2.0, 0.05)
 ///         .with_max(Duration::from_secs(30))
 /// });
 /// ```
 pub struct ExpBackoffStrategy {
     min: Duration,
     max: Option<Duration>,
-    factor: u32,
+    factor: f64,
     jitter: f64,
     seed: Option<u64>,
 }
 
 impl ExpBackoffStrategy {
-    pub fn new(min: Duration, factor: u32, jitter: f64) -> Self {
+    pub fn new(min: Duration, factor: f64, jitter: f64) -> Self {
         Self {
             min,
             max: None,
@@ -71,6 +49,18 @@ impl ExpBackoffStrategy {
     pub fn with_seed(mut self, seed: u64) -> Self {
         self.seed = Some(seed);
         self
+    }
+}
+
+impl Default for ExpBackoffStrategy {
+    fn default() -> Self {
+        Self {
+            min: Duration::from_secs(5),
+            max: Some(Duration::from_secs(30 * 60)),
+            factor: 1.5,
+            jitter: 0.5,
+            seed: None,
+        }
     }
 }
 
@@ -107,7 +97,7 @@ impl Iterator for ExpBackoffIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.pow += 1;
-        let base = self.init * self.strategy.factor.pow(self.pow) as f64;
+        let base = self.init * self.strategy.factor.powf(self.pow as f64);
         let jitter = base * self.strategy.jitter * (self.rng.gen::<f64>() * 2. - 1.);
         let current = Duration::from_secs_f64(base + jitter);
         match self.strategy.max {
@@ -122,33 +112,29 @@ mod test {
     use super::ExpBackoffStrategy;
     use std::time::Duration;
 
-    macro_rules! assert_close_to {
-        ($item:expr, $value:expr) => {
-            assert_close_to!($item, $value, 0.001_f64)
-        };
-        ($item:expr, $value:expr, $eps: expr) => {
-            assert!($item >= ($value - $eps));
-            assert!($item <= ($value + $eps));
-        };
-    }
-
     #[test]
     fn test_exponential_backoff_jitter_bounds() {
-        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 2, 0.1).into_iter();
-        let first = backoff_iter.next();
-        assert_close_to!(first.unwrap().as_secs_f64(), 2.0_f64, 0.2_f64);
-        let second = backoff_iter.next();
-        assert_close_to!(second.unwrap().as_secs_f64(), 4.0_f64, 0.4_f64);
+        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 2., 0.1)
+            .with_seed(0)
+            .into_iter();
+        for idx in 1..10 {
+            let value = backoff_iter.next().unwrap().as_secs_f64();
+            let lower_bound = 2_u32.pow(idx) as f64 * 0.9;
+            let upper_bound = 2_u32.pow(idx) as f64 * 1.1;
+            assert!(value.total_cmp(&lower_bound).is_ge());
+            assert!(value.total_cmp(&upper_bound).is_le());
+        }
     }
 
     #[test]
     fn test_exponential_backoff_max_value() {
-        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 4, 0.0)
+        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 4., 0.0)
+            .with_seed(0)
             .with_max(Duration::from_secs(2))
             .into_iter();
-        let first = backoff_iter.next();
-        assert_close_to!(first.unwrap().as_secs_f64(), 2.0);
-        let second = backoff_iter.next();
-        assert_close_to!(second.unwrap().as_secs_f64(), 2.0);
+        for _ in 1..2 {
+            let value = backoff_iter.next().unwrap().as_secs_f64();
+            assert!(value.total_cmp(&2.0).is_eq());
+        }
     }
 }

--- a/src/strategies.rs
+++ b/src/strategies.rs
@@ -55,10 +55,10 @@ impl ExpBackoffStrategy {
 impl Default for ExpBackoffStrategy {
     fn default() -> Self {
         Self {
-            min: Duration::from_secs(5),
+            min: Duration::from_secs(4),
             max: Some(Duration::from_secs(30 * 60)),
-            factor: 1.5,
-            jitter: 0.5,
+            factor: 2.0,
+            jitter: 0.05,
             seed: None,
         }
     }

--- a/src/strategies.rs
+++ b/src/strategies.rs
@@ -130,20 +130,20 @@ mod test {
         ];
         for expected in expected_values {
             let value = backoff_iter.next().unwrap().as_secs_f64();
-            assert!(value.total_cmp(&expected).is_eq());
+            assert!(value.total_cmp(&expected).is_eq(), "{value} != {expected}");
         }
     }
 
     #[test]
     fn test_exponential_backoff_max_value() {
-        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 4., 0.0)
+        let mut backoff_iter = ExpBackoffStrategy::new(Duration::from_secs(1), 2., 0.0)
             .with_seed(0)
-            .with_max(Duration::from_secs(2))
+            .with_max(Duration::from_secs(8))
             .into_iter();
-        let expected_values = [1.0, 2.0, 2.0];
+        let expected_values = [1.0, 2.0, 4.0, 8.0, 8.0];
         for expected in expected_values {
             let value = backoff_iter.next().unwrap().as_secs_f64();
-            assert!(value.total_cmp(&expected).is_eq());
+            assert!(value.total_cmp(&expected).is_eq(), "{value} != {expected}");
         }
     }
 }


### PR DESCRIPTION
Adds a customizable exponential backoff strategy.

strategy includes
- optional maximum value to act as upper bound on returned durations
- jitter as a ratio, `0.10` corresponds to a +/-10% jitter on returned durations
- optional `seed` field for seeded random number generation, defaults to using entropy