### PR TITLE
Ensure multiple shutdown attempts yield

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stubborn-io"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["David Raifaizen <david.raifaizen@protonmail.com>"]
 edition = "2021"
 description = "io traits/structs that automatically recover from potential disconnections/interruptions."

--- a/src/tokio/io.rs
+++ b/src/tokio/io.rs
@@ -381,7 +381,7 @@ where
 
                 poll
             }
-            Status::Disconnected(_) => Poll::Pending,
+            Status::Disconnected(_) => exhausted_err(),
             Status::FailedAndExhausted => exhausted_err(),
         }
     }

--- a/tests/dummy_tests.rs
+++ b/tests/dummy_tests.rs
@@ -175,31 +175,6 @@ mod already_connected {
     use tokio_util::codec::{Framed, LinesCodec};
 
     #[tokio::test]
-    async fn back_to_back_shutdown_attempts() {
-        use stubborn_io::StubbornTcpStream;
-        use tokio::io::AsyncWriteExt;
-
-        const ADDR: &str = "127.0.0.1:3989";
-
-        tokio::spawn(async move {
-            let mut streams = Vec::new();
-            let listener = tokio::net::TcpListener::bind(ADDR).await.unwrap();
-            loop {
-                let (stream, _addr) = listener.accept().await.unwrap();
-                streams.push(stream);
-            }
-        });
-        tokio::time::sleep(Duration::from_secs(1)).await;
-        let mut connection = StubbornTcpStream::connect(ADDR).await.unwrap();
-
-        connection.shutdown().await.unwrap();
-        let elapsed = tokio::time::timeout(Duration::from_secs(5), connection.shutdown()).await;
-
-        let result = elapsed.unwrap();
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
     async fn should_ignore_non_fatal_errors_and_continue_as_connected() {
         let connect_outcomes = Arc::new(Mutex::new(vec![true]));
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -23,5 +23,6 @@ async fn back_to_back_shutdown_attempts() {
     let elapsed = tokio::time::timeout(Duration::from_secs(5), connection.shutdown()).await;
 
     let result = elapsed.unwrap();
-    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::NotConnected);
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use stubborn_io::StubbornTcpStream;
+use tokio::{io::AsyncWriteExt, sync::oneshot};
+
+#[tokio::test]
+async fn back_to_back_shutdown_attempts() {
+    let (port_tx, port_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut streams = Vec::new();
+        let listener = tokio::net::TcpListener::bind("0.0.0.0:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        port_tx.send(addr).unwrap();
+        loop {
+            let (stream, _addr) = listener.accept().await.unwrap();
+            streams.push(stream);
+        }
+    });
+    let addr = port_rx.await.unwrap();
+    let mut connection = StubbornTcpStream::connect(addr).await.unwrap();
+
+    connection.shutdown().await.unwrap();
+    let elapsed = tokio::time::timeout(Duration::from_secs(5), connection.shutdown()).await;
+
+    let result = elapsed.unwrap();
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Currently if the state is set to disconnect, and the user hits `poll_shutdown`, the function will never yield.

```rust
let mut connection = StubbornTcpStream::connect(ADDR).await.unwrap();
let _ = connection.shutdown().await;
let _ = connection.shutdown().await; // Second attempt never yields
```

My proposed solution (similar to how tokio operates) is to just error in the event a closed stream is told to shutdown again.