### PR TITLE
Relaxing sync on reconnect options as it does not appear to be needed

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,26 +4,26 @@
 use crate::strategies::ExpBackoffStrategy;
 use std::time::Duration;
 
-pub type DurationIterator = Box<dyn Iterator<Item = Duration> + Send + Sync>;
+pub type DurationIterator = Box<dyn Iterator<Item = Duration> + Send>;
 
 /// User specified options that control the behavior of the stubborn-io upon disconnect.
 pub struct ReconnectOptions {
     /// Represents a function that generates an Iterator
     /// to schedule the wait between reconnection attempts.
-    pub retries_to_attempt_fn: Box<dyn Fn() -> DurationIterator + Send + Sync>,
+    pub retries_to_attempt_fn: Box<dyn Fn() -> DurationIterator + Send>,
 
     /// If this is set to true, if the initial connect method of the stubborn-io item fails,
     /// then no further reconnects will be attempted
     pub exit_if_first_connect_fails: bool,
 
     /// Invoked when the StubbornIo establishes a connection
-    pub on_connect_callback: Box<dyn Fn() + Send + Sync>,
+    pub on_connect_callback: Box<dyn Fn() + Send>,
 
     /// Invoked when the StubbornIo loses its active connection
-    pub on_disconnect_callback: Box<dyn Fn() + Send + Sync>,
+    pub on_disconnect_callback: Box<dyn Fn() + Send>,
 
     /// Invoked when the StubbornIo fails a connection attempt
-    pub on_connect_fail_callback: Box<dyn Fn() + Send + Sync>,
+    pub on_connect_fail_callback: Box<dyn Fn() + Send>,
 }
 
 impl ReconnectOptions {

--- a/tests/dummy_tests.rs
+++ b/tests/dummy_tests.rs
@@ -100,7 +100,11 @@ pub mod instantiating {
             ..DummyCtor::default()
         };
 
-        let dummy = StubbornDummy::connect(ctor).await;
+        let mut opts = ReconnectOptions::new();
+        opts.retries_to_attempt_fn =
+            Box::new(|| Box::new(vec![Duration::from_millis(1)].into_iter()));
+
+        let dummy = StubbornDummy::connect_with_options(ctor, opts).await;
 
         assert!(dummy.is_ok());
     }


### PR DESCRIPTION
Attempting to see if, by removing the Sync bound on the ReconnectOptions, we can fix the issue reported in https://github.com/craftytrickster/stubborn-io/issues/29 .